### PR TITLE
added support for crazy unicode in the value of custom fields

### DIFF
--- a/custom_field/models.py
+++ b/custom_field/models.py
@@ -43,10 +43,7 @@ class CustomFieldValue(models.Model):
     content_object = generic.GenericForeignKey('content_type', 'object_id')
 
     def __unicode__(self):
-        if type(self.value) == str:
-            return self.value
-        elif type(self.value) == unicode:
-            return self.value.encode('utf-8')
+        return convert_string_of_unknown_type_to_unicode(self.value)
 
     def save(self, *args, **kwargs):
         super(CustomFieldValue, self).save(*args, **kwargs)
@@ -73,3 +70,12 @@ class CustomFieldValue(models.Model):
 
     class Meta:
         unique_together = ('field', 'object_id')
+
+def convert_string_of_unknown_type_to_unicode(string):
+    try:
+        return string.decode('utf-8')
+    except UnicodeDecodeError:
+        return string.decode("ascii", "ignore")
+    except UnicodeEncodeError:
+        return string.encode("utf-8")
+

--- a/custom_field/models.py
+++ b/custom_field/models.py
@@ -43,7 +43,10 @@ class CustomFieldValue(models.Model):
     content_object = generic.GenericForeignKey('content_type', 'object_id')
 
     def __unicode__(self):
-        return str('{}'.format(self.value))
+        if type(self.value) == str:
+            return self.value
+        elif type(self.value) == unicode:
+            return self.value.encode('utf-8')
 
     def save(self, *args, **kwargs):
         super(CustomFieldValue, self).save(*args, **kwargs)

--- a/custom_field/tests.py
+++ b/custom_field/tests.py
@@ -4,7 +4,9 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.contrib.auth.models import User
 from django.test import TestCase
-from .models import CustomField, CustomFieldValue
+from .models import (
+    CustomField, CustomFieldValue,convert_string_of_unknown_type_to_unicode
+    )
 from .custom_field import CustomFieldAdmin
 
 
@@ -56,28 +58,29 @@ class CustomFieldTest(TestCase):
         # Make sure we aren't adding it on each get
         self.assertContains(response, '42', count=2)
 
-    def create_and_test_custom_field_unicode_method(self, char_string):
-        custom_field = CustomFieldValue.objects.create(
-            field = self.custom_field,
-            value = char_string,
-            object_id = self.custom_field.id
-        )
-        self.assertEqual(type(custom_field.__unicode__()),str)
-
     def test_crazy_string_that_should_be_unicode_but_isnt(self):
         chars = "ȧƈƈḗƞŧḗḓ ŧḗẋŧ ƒǿř ŧḗşŧīƞɠ"
-        self.create_and_test_custom_field_unicode_method(chars)
+        decoded_chars = convert_string_of_unknown_type_to_unicode(chars)
+        self.assertEqual(type(decoded_chars), unicode)
 
     def test_crazy_unicode_string(self):
         chars = "ȧƈƈḗƞŧḗḓ ŧḗẋŧ ƒǿř ŧḗşŧīƞɠ"
-        self.create_and_test_custom_field_unicode_method(chars)
+        decoded_chars = convert_string_of_unknown_type_to_unicode(chars)
+        self.assertEqual(type(decoded_chars), unicode)
 
     def test_normal_string(self):
         chars = "Hello World"
-        self.create_and_test_custom_field_unicode_method(chars)
+        decoded_chars = convert_string_of_unknown_type_to_unicode(chars)
+        self.assertEqual(type(decoded_chars), unicode)
 
     def test_unicode_string(self):
         chars = u'\xa0'
-        self.create_and_test_custom_field_unicode_method(chars)
+        decoded_chars = convert_string_of_unknown_type_to_unicode(chars)
+        self.assertEqual(type(decoded_chars), unicode)
+
+    def test_unicode_string(self):
+        chars = u'\kjnsdfjkbnsdjknkijbnskbhdf'
+        decoded_chars = convert_string_of_unknown_type_to_unicode(chars)
+        self.assertEqual(type(decoded_chars), unicode)
 
 

--- a/custom_field/tests.py
+++ b/custom_field/tests.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.contrib.auth.models import User
@@ -53,3 +55,29 @@ class CustomFieldTest(TestCase):
         response = self.client.get('/admin/custom_field/customfield/1/') 
         # Make sure we aren't adding it on each get
         self.assertContains(response, '42', count=2)
+
+    def create_and_test_custom_field_unicode_method(self, char_string):
+        custom_field = CustomFieldValue.objects.create(
+            field = self.custom_field,
+            value = char_string,
+            object_id = self.custom_field.id
+        )
+        self.assertEqual(type(custom_field.__unicode__()),str)
+
+    def test_crazy_string_that_should_be_unicode_but_isnt(self):
+        chars = "ȧƈƈḗƞŧḗḓ ŧḗẋŧ ƒǿř ŧḗşŧīƞɠ"
+        self.create_and_test_custom_field_unicode_method(chars)
+
+    def test_crazy_unicode_string(self):
+        chars = "ȧƈƈḗƞŧḗḓ ŧḗẋŧ ƒǿř ŧḗşŧīƞɠ"
+        self.create_and_test_custom_field_unicode_method(chars)
+
+    def test_normal_string(self):
+        chars = "Hello World"
+        self.create_and_test_custom_field_unicode_method(chars)
+
+    def test_unicode_string(self):
+        chars = u'\xa0'
+        self.create_and_test_custom_field_unicode_method(chars)
+
+


### PR DESCRIPTION
Hey @bufke here's what I've come up with tonight... as it turns out I don't have commit access to django-custom-field so a pull-request here will do. Hard to figure out what the user is doing, but these tests seems to say that this works. I'm somewhat losing my mind over this stuff!!!
